### PR TITLE
Make ddtxn go-gettable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,4 @@
 *.test
 *.out
 *.err
-benchmarks/rubis
-benchmarks/buy
-benchmarks/tmp
-benchmarks/bench
-benchmarks/big
-benchmarks/single
 *.out.?
-benchmarks/time-single
-benchmarks/bid

--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ Doppel's design is described in ["Phase Reconciliation for Contended
 In-Memory Transactions"](http://pdos.csail.mit.edu/~neha/phaser.pdf),
 presented at OSDI 2014.
 
-To run Doppel, install go from source following the instructions here:<br>
-`https://golang.org/doc/install/source`
+To run Doppel, install go from source following the instructions here:
+https://golang.org/doc/install/source.
 
-Clone the Doppel code into your $GOPATH/src/ directory:<br>
-`cd $GOPATH/src/`<br>
-`git clone https://github.com/narula/ddtxn.git`
+Then `go get` the code:
 
-Run the tests:<br>
-`cd ddtxn`<br>
-`go test`
+    go get github.com/narula/ddtxn/...
 
-Add bin/ to your PATH<br>
+The code will be at `$GOPATH/src/github.com/narula/ddtxn`.
 
-Run a benchmark:<br>
-`cd ddtxn/benchmarks`<br>
-`go build single.go`<br>
-`python bm.py --exp=single --rlock --ncores=N`
+To run the tests, use `go test`.
+
+Add `$GOPATH/bin` to your `PATH` environment variable.
+
+Run a benchmark:
+
+    cd $GOPATH/github.com/narula/ddtxn/benchmarks
+    go install ./single
+    python bm.py --exp=single --rlock --ncores=N

--- a/apps/big.go
+++ b/apps/big.go
@@ -1,8 +1,9 @@
 package apps
 
 import (
-	"ddtxn"
 	"flag"
+
+	"github.com/narula/ddtxn"
 )
 
 var incr = flag.Bool("incr", true, "Do incr or RW workload")

--- a/apps/buy.go
+++ b/apps/buy.go
@@ -1,12 +1,13 @@
 package apps
 
 import (
-	"ddtxn"
-	"ddtxn/dlog"
 	"flag"
 	"fmt"
 	"math/rand"
 	"sync/atomic"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/dlog"
 )
 
 var partition = flag.Bool("partition", false, "Whether or not to partition the non-contended keys amongst the cores")

--- a/apps/rubis.go
+++ b/apps/rubis.go
@@ -1,14 +1,15 @@
 package apps
 
 import (
-	"ddtxn"
-	"ddtxn/dlog"
 	"fmt"
 	"log"
 	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/dlog"
 )
 
 type Rubis struct {

--- a/auction.go
+++ b/auction.go
@@ -1,10 +1,11 @@
 package ddtxn
 
 import (
-	"ddtxn/dlog"
 	"fmt"
 	"log"
 	"time"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 const (

--- a/benchmarks/bid/bid.go
+++ b/benchmarks/bid/bid.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"container/heap"
-	"ddtxn"
-	"ddtxn/apps"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -15,6 +11,11 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/apps"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")

--- a/benchmarks/big/big.go
+++ b/benchmarks/big/big.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"ddtxn"
-	"ddtxn/apps"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -13,6 +9,11 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/apps"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")

--- a/benchmarks/bm.py
+++ b/benchmarks/bm.py
@@ -36,7 +36,7 @@ ben_list_cpus = "thread==0 socket@0,1,2,7,3-6"
 LATENCY_PART = " -latency=%s" % options.latency
 VERSION_PART = " -v=%d" % options.version
 
-BASE_CMD = "GOGC=off numactl -C `list-cpus seq -n %d %s` ./%s -nprocs=%d -ngo=%d -nw=%d -nsec=%d -contention=%s -rr=%d -allocate=%s -sys=%d -rlock=%s -wr=%s -phase=%s -sr=%d -atomic=%s -zipf=%s -out=data.out -ncrr=%s -cw=%.2f -rw=%.2f -split=%s" + LATENCY_PART + VERSION_PART
+BASE_CMD = "GOGC=off numactl -C `list-cpus seq -n %d %s` $GOPATH/bin/%s -nprocs=%d -ngo=%d -nw=%d -nsec=%d -contention=%s -rr=%d -allocate=%s -sys=%d -rlock=%s -wr=%s -phase=%s -sr=%d -atomic=%s -zipf=%s -out=data.out -ncrr=%s -cw=%.2f -rw=%.2f -split=%s" + LATENCY_PART + VERSION_PART
 
 def do_param(bn, rr, contention, ncpu, sys, wratio=options.wratio, phase=options.phase, atomic=False, zipf=-1, ncrr=options.not_contended_read_rate, yval="total/sec", cw=options.conflict_weight, rw=options.read_weight, split=False):
     cmd = fill_cmd(bn, rr, contention, ncpu, sys, wratio, phase, atomic, zipf, ncrr, cw, rw, split)
@@ -269,7 +269,7 @@ if __name__ == "__main__":
 
     # figure 8
     if options.exp == "single" or options.exp == "all":
-        single_exp(0, options.default_ncores)        
+        single_exp(0, options.default_ncores)
     # figure 9
     if options.exp == "singlescale" or options.exp == "all":
         single_scale_exp(host, 100, 0, -1)

--- a/benchmarks/buy/buy.go
+++ b/benchmarks/buy/buy.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"container/heap"
-	"ddtxn"
-	"ddtxn/apps"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -15,6 +11,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/apps"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")

--- a/benchmarks/rubis/rubis.go
+++ b/benchmarks/rubis/rubis.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"container/heap"
-	"ddtxn"
-	"ddtxn/apps"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -15,6 +11,11 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/apps"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")

--- a/benchmarks/single/single.go
+++ b/benchmarks/single/single.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"container/heap"
-	"ddtxn"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -13,6 +10,10 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")
@@ -22,9 +23,9 @@ var nworkers = flag.Int("nw", 0, "Number of workers")
 var nbidders = flag.Int("nb", 1000000, "Keys in store, default is 1M")
 var prob = flag.Float64("contention", 100.0, "Probability contended key is in txn. -1 means zipfian distribution and we use ZipfDist")
 var readrate = flag.Int("rr", 0, "Read rate %.  Rest are writes")
-var dataFile = flag.String("out", "time-data.out", "Filename for output")
+var dataFile = flag.String("out", "xdata.out", "Filename for output")
 var atomicIncr = flag.Bool("atomic", false, "Workload of just atomic increments")
-var notcontended_readrate = flag.Float64("ncrr", 5.0, "Time to change hot key")
+var notcontended_readrate = flag.Float64("ncrr", .8, "NOT USED")
 
 var ZipfDist = flag.Float64("zipf", 1, "Zipfian distribution theta.  1 means only 1 hot key and we'll vary the percentage (single exp)")
 var partition = flag.Bool("partition", false, "Whether or not to partition the non-contended keys amongst the cores")
@@ -61,10 +62,10 @@ func main() {
 		}
 	}
 
-	changeDelta := *notcontended_readrate
 	dlog.Printf("Done initializing single\n")
 
 	p := prof.StartProfile()
+	start := time.Now()
 	sp := uint32(*nbidders / *nworkers)
 	var wg sync.WaitGroup
 	pkey := int(sp - 1)
@@ -81,11 +82,11 @@ func main() {
 			}
 		}
 	}
-	start := time.Now()
+
 	for i := 0; i < *clientGoRoutines; i++ {
 		wg.Add(1)
 		go func(n int) {
-			exp := ddtxn.MakeExp(30)
+			exp := ddtxn.MakeExp(50)
 			retries := make(ddtxn.RetryHeap, 0)
 			heap.Init(&retries)
 			var local_seed uint32 = uint32(rand.Intn(10000000))
@@ -93,35 +94,12 @@ func main() {
 			w := coord.Workers[wi]
 			top := (wi + 1) * int(sp)
 			bottom := wi * int(sp)
-			delta := 0
-			xval := 0
 			dlog.Printf("%v: Noncontended section: %v to %v\n", n, bottom, top)
 			end_time := time.Now().Add(time.Duration(*nsec) * time.Second)
-			change_time := time.Now().Add(time.Duration(changeDelta) * time.Second)
-			log_time := time.Now().Add(time.Duration(1000) * time.Millisecond)
-			start2 := time.Now()
-			var ndone int64
 			for {
 				tm := time.Now()
 				if !end_time.After(tm) {
 					break
-				}
-				if changeDelta > 0 && tm.After(change_time) {
-					pkey = (int(sp) * (delta % *nworkers))
-					delta++
-					change_time = time.Now().Add(time.Duration(changeDelta) * time.Second)
-				}
-				if tm.After(log_time) && wi == 0 {
-					end2 := time.Since(start2)
-					var total int64
-					for i := 0; i < *nworkers; i++ {
-						total = total + ddtxn.CollectOne(coord.Workers[i])
-					}
-					fmt.Printf("%v:%v:%v:%v\n", *ddtxn.SysType, xval, n, float64(total-ndone)/end2.Seconds())
-					ndone = total
-					start2 = time.Now()
-					log_time = time.Now().Add(time.Duration(1000) * time.Millisecond)
-					xval++
 				}
 				var t ddtxn.Query
 				if len(retries) > 0 && retries[0].TS.Before(tm) {
@@ -172,7 +150,15 @@ func main() {
 				}
 				t.I++
 				if !committed {
-					t.TS = tm.Add(time.Duration(ddtxn.RandN(&local_seed, exp.Exp(t.I))) * time.Microsecond)
+					e := exp.Exp(t.I)
+					if e <= 0 {
+						e = 1
+					}
+					rnd := ddtxn.RandN(&local_seed, e)
+					if rnd <= 0 {
+						rnd = 1
+					}
+					t.TS = tm.Add(time.Duration(rnd) * time.Microsecond)
 					if t.TS.Before(end_time) {
 						heap.Push(&retries, t)
 					} else {
@@ -180,6 +166,7 @@ func main() {
 					}
 				}
 			}
+			w.Finished()
 			wg.Done()
 			if len(retries) > 0 {
 				dlog.Printf("[%v] Length of retry queue on exit: %v\n", n, len(retries))
@@ -193,7 +180,7 @@ func main() {
 	p.Stop()
 
 	stats := make([]int64, ddtxn.LAST_STAT)
-	nitr, nwait, _ := ddtxn.CollectCounts(coord, stats)
+	nitr, nwait, _, _, _, _, _ := ddtxn.CollectCounts(coord, stats)
 
 	for i := 1; i < *clientGoRoutines; i++ {
 		gave_up[0] = gave_up[0] + gave_up[i]
@@ -203,8 +190,8 @@ func main() {
 	// stashed transaction eventually executes and contributes to
 	// nitr.
 	out := fmt.Sprintf(" nworkers: %v, nwmoved: %v, nrmoved: %v, sys: %v, total/sec: %v, abortrate: %.2f, stashrate: %.2f, rr: %v, nkeys: %v, contention: %v, zipf: %v, done: %v, actual time: %v, nreads: %v, nincrs: %v, epoch changes: %v, throughput ns/txn: %v, naborts: %v, coord time: %v, coord stats time: %v, total worker time transitioning: %v, nstashed: %v, rlock: %v, wrratio: %v, nsamples: %v, getkeys: %v, ddwrites: %v, nolock: %v, failv: %v, nlocked: %v, stashdone: %v, nfast: %v, gaveup: %v, potential: %v ", *nworkers, ddtxn.WMoved, ddtxn.RMoved, *ddtxn.SysType, float64(nitr)/end.Seconds(), 100*float64(stats[ddtxn.NABORTS])/float64(nitr+stats[ddtxn.NABORTS]), 100*float64(stats[ddtxn.NSTASHED])/float64(nitr+stats[ddtxn.NABORTS]), *readrate, *nbidders, *prob, *ZipfDist, nitr, end, stats[ddtxn.D_READ_ONE], stats[ddtxn.D_INCR_ONE], ddtxn.NextEpoch, end.Nanoseconds()/nitr, stats[ddtxn.NABORTS], ddtxn.Time_in_IE, ddtxn.Time_in_IE1, nwait, stats[ddtxn.NSTASHED], *ddtxn.UseRLocks, *ddtxn.WRRatio, stats[ddtxn.NSAMPLES], stats[ddtxn.NGETKEYCALLS], stats[ddtxn.NDDWRITES], stats[ddtxn.NO_LOCK], stats[ddtxn.NFAIL_VERIFY], stats[ddtxn.NLOCKED], stats[ddtxn.NDIDSTASHED], ddtxn.Nfast, gave_up[0], coord.PotentialPhaseChanges)
-	//	fmt.Printf(out)
-	//	fmt.Printf("\n")
+	fmt.Printf(out)
+	fmt.Printf("\n")
 
 	f, err := os.OpenFile(*dataFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {

--- a/benchmarks/time-single/time-single.go
+++ b/benchmarks/time-single/time-single.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"container/heap"
-	"ddtxn"
-	"ddtxn/dlog"
-	"ddtxn/prof"
 	"flag"
 	"fmt"
 	"log"
@@ -13,6 +10,10 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/narula/ddtxn"
+	"github.com/narula/ddtxn/dlog"
+	"github.com/narula/ddtxn/prof"
 )
 
 var nprocs = flag.Int("nprocs", 2, "GOMAXPROCS default 2")
@@ -22,9 +23,9 @@ var nworkers = flag.Int("nw", 0, "Number of workers")
 var nbidders = flag.Int("nb", 1000000, "Keys in store, default is 1M")
 var prob = flag.Float64("contention", 100.0, "Probability contended key is in txn. -1 means zipfian distribution and we use ZipfDist")
 var readrate = flag.Int("rr", 0, "Read rate %.  Rest are writes")
-var dataFile = flag.String("out", "xdata.out", "Filename for output")
+var dataFile = flag.String("out", "time-data.out", "Filename for output")
 var atomicIncr = flag.Bool("atomic", false, "Workload of just atomic increments")
-var notcontended_readrate = flag.Float64("ncrr", .8, "NOT USED")
+var notcontended_readrate = flag.Float64("ncrr", 5.0, "Time to change hot key")
 
 var ZipfDist = flag.Float64("zipf", 1, "Zipfian distribution theta.  1 means only 1 hot key and we'll vary the percentage (single exp)")
 var partition = flag.Bool("partition", false, "Whether or not to partition the non-contended keys amongst the cores")
@@ -61,10 +62,10 @@ func main() {
 		}
 	}
 
+	changeDelta := *notcontended_readrate
 	dlog.Printf("Done initializing single\n")
 
 	p := prof.StartProfile()
-	start := time.Now()
 	sp := uint32(*nbidders / *nworkers)
 	var wg sync.WaitGroup
 	pkey := int(sp - 1)
@@ -81,11 +82,11 @@ func main() {
 			}
 		}
 	}
-
+	start := time.Now()
 	for i := 0; i < *clientGoRoutines; i++ {
 		wg.Add(1)
 		go func(n int) {
-			exp := ddtxn.MakeExp(50)
+			exp := ddtxn.MakeExp(30)
 			retries := make(ddtxn.RetryHeap, 0)
 			heap.Init(&retries)
 			var local_seed uint32 = uint32(rand.Intn(10000000))
@@ -93,12 +94,35 @@ func main() {
 			w := coord.Workers[wi]
 			top := (wi + 1) * int(sp)
 			bottom := wi * int(sp)
+			delta := 0
+			xval := 0
 			dlog.Printf("%v: Noncontended section: %v to %v\n", n, bottom, top)
 			end_time := time.Now().Add(time.Duration(*nsec) * time.Second)
+			change_time := time.Now().Add(time.Duration(changeDelta) * time.Second)
+			log_time := time.Now().Add(time.Duration(1000) * time.Millisecond)
+			start2 := time.Now()
+			var ndone int64
 			for {
 				tm := time.Now()
 				if !end_time.After(tm) {
 					break
+				}
+				if changeDelta > 0 && tm.After(change_time) {
+					pkey = (int(sp) * (delta % *nworkers))
+					delta++
+					change_time = time.Now().Add(time.Duration(changeDelta) * time.Second)
+				}
+				if tm.After(log_time) && wi == 0 {
+					end2 := time.Since(start2)
+					var total int64
+					for i := 0; i < *nworkers; i++ {
+						total = total + ddtxn.CollectOne(coord.Workers[i])
+					}
+					fmt.Printf("%v:%v:%v:%v\n", *ddtxn.SysType, xval, n, float64(total-ndone)/end2.Seconds())
+					ndone = total
+					start2 = time.Now()
+					log_time = time.Now().Add(time.Duration(1000) * time.Millisecond)
+					xval++
 				}
 				var t ddtxn.Query
 				if len(retries) > 0 && retries[0].TS.Before(tm) {
@@ -149,15 +173,7 @@ func main() {
 				}
 				t.I++
 				if !committed {
-					e := exp.Exp(t.I)
-					if e <= 0 {
-						e = 1
-					}
-					rnd := ddtxn.RandN(&local_seed, e)
-					if rnd <= 0 {
-						rnd = 1
-					}
-					t.TS = tm.Add(time.Duration(rnd) * time.Microsecond)
+					t.TS = tm.Add(time.Duration(ddtxn.RandN(&local_seed, exp.Exp(t.I))) * time.Microsecond)
 					if t.TS.Before(end_time) {
 						heap.Push(&retries, t)
 					} else {
@@ -165,7 +181,6 @@ func main() {
 					}
 				}
 			}
-			w.Finished()
 			wg.Done()
 			if len(retries) > 0 {
 				dlog.Printf("[%v] Length of retry queue on exit: %v\n", n, len(retries))
@@ -179,7 +194,7 @@ func main() {
 	p.Stop()
 
 	stats := make([]int64, ddtxn.LAST_STAT)
-	nitr, nwait, _, _, _, _, _ := ddtxn.CollectCounts(coord, stats)
+	nitr, nwait, _ := ddtxn.CollectCounts(coord, stats)
 
 	for i := 1; i < *clientGoRoutines; i++ {
 		gave_up[0] = gave_up[0] + gave_up[i]
@@ -189,8 +204,8 @@ func main() {
 	// stashed transaction eventually executes and contributes to
 	// nitr.
 	out := fmt.Sprintf(" nworkers: %v, nwmoved: %v, nrmoved: %v, sys: %v, total/sec: %v, abortrate: %.2f, stashrate: %.2f, rr: %v, nkeys: %v, contention: %v, zipf: %v, done: %v, actual time: %v, nreads: %v, nincrs: %v, epoch changes: %v, throughput ns/txn: %v, naborts: %v, coord time: %v, coord stats time: %v, total worker time transitioning: %v, nstashed: %v, rlock: %v, wrratio: %v, nsamples: %v, getkeys: %v, ddwrites: %v, nolock: %v, failv: %v, nlocked: %v, stashdone: %v, nfast: %v, gaveup: %v, potential: %v ", *nworkers, ddtxn.WMoved, ddtxn.RMoved, *ddtxn.SysType, float64(nitr)/end.Seconds(), 100*float64(stats[ddtxn.NABORTS])/float64(nitr+stats[ddtxn.NABORTS]), 100*float64(stats[ddtxn.NSTASHED])/float64(nitr+stats[ddtxn.NABORTS]), *readrate, *nbidders, *prob, *ZipfDist, nitr, end, stats[ddtxn.D_READ_ONE], stats[ddtxn.D_INCR_ONE], ddtxn.NextEpoch, end.Nanoseconds()/nitr, stats[ddtxn.NABORTS], ddtxn.Time_in_IE, ddtxn.Time_in_IE1, nwait, stats[ddtxn.NSTASHED], *ddtxn.UseRLocks, *ddtxn.WRRatio, stats[ddtxn.NSAMPLES], stats[ddtxn.NGETKEYCALLS], stats[ddtxn.NDDWRITES], stats[ddtxn.NO_LOCK], stats[ddtxn.NFAIL_VERIFY], stats[ddtxn.NLOCKED], stats[ddtxn.NDIDSTASHED], ddtxn.Nfast, gave_up[0], coord.PotentialPhaseChanges)
-	fmt.Printf(out)
-	fmt.Printf("\n")
+	//	fmt.Printf(out)
+	//	fmt.Printf("\n")
 
 	f, err := os.OpenFile(*dataFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {

--- a/coordinator.go
+++ b/coordinator.go
@@ -2,12 +2,13 @@ package ddtxn
 
 import (
 	"container/heap"
-	"ddtxn/dlog"
 	"flag"
 	"fmt"
 	"log"
 	"sync/atomic"
 	"time"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 const (

--- a/execute.go
+++ b/execute.go
@@ -1,10 +1,11 @@
 package ddtxn
 
 import (
-	"ddtxn/dlog"
 	"flag"
 	"log"
 	"math/rand"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 var SampleRate = flag.Int64("sr", 500, "Sample every sr transactions\n")

--- a/local_store.go
+++ b/local_store.go
@@ -1,9 +1,10 @@
 package ddtxn
 
 import (
-	"ddtxn/dlog"
 	"log"
 	"runtime/debug"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 // Local per-worker store. Specific types to more quickly apply local

--- a/record.go
+++ b/record.go
@@ -1,12 +1,13 @@
 package ddtxn
 
 import (
-	"ddtxn/spinlock"
-	"ddtxn/wfmutex"
 	"flag"
 	"log"
 	"sync"
 	"sync/atomic"
+
+	"github.com/narula/ddtxn/spinlock"
+	"github.com/narula/ddtxn/wfmutex"
 )
 
 var Conflicts = flag.Bool("conflicts", false, "Measure conflicts\n")

--- a/store.go
+++ b/store.go
@@ -1,12 +1,13 @@
 package ddtxn
 
 import (
-	"ddtxn/dlog"
 	"errors"
 	"flag"
 	"log"
 	"runtime/debug"
 	"sync"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 type TID uint64

--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package ddtxn
 
 import (
 	crand "crypto/rand"
-	"ddtxn/dlog"
 	"fmt"
 	"log"
 	"math"
@@ -10,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 type Exp2 struct {

--- a/worker.go
+++ b/worker.go
@@ -1,7 +1,6 @@
 package ddtxn
 
 import (
-	"ddtxn/dlog"
 	"flag"
 	"log"
 	"runtime/debug"
@@ -9,6 +8,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/narula/ddtxn/dlog"
 )
 
 const (


### PR DESCRIPTION
This makes a number of changes:
- Changes all `ddtxn/*` imports into the full `github.com/narula/ddtxn` paths.
- Moves all benchmarks into their own directories. This allows the use of `go install` to build and install the binaries.
- Changes `bm.py` to expect the benchmark binaries to be in `$GOPATH/bin/`.
- Freshens the README a bit.

(Now, without nuking the benchmarks!)
